### PR TITLE
This role is now deprecated in favor of f500.php7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-php_dev
+Deprecated
+==========
+
+**This role is deprecated. Please use the role [f500.php7](https://github.com/f500/ansible-php7), v1.0.0 or higher.**
+
+---
+
+PHP7_DEV
 ========
 
 Install latest PHP (development package) version in DotDeb repository
@@ -13,16 +20,18 @@ Example Playbook
 
     - hosts: servers
       roles:
-         - { role: f500.php7_dev }
+        - { role: f500.php7_dev }
 
 License
 -------
 
-LGPL
+Copyright (C) 2017 Future500 B.V.
+
+[LGPL-3.0](https://github.com/f500/ansible-php7_dev/blob/master/COPYING.LESSER)
 
 Author Information
 ------------------
 
-Jasper N. Brouwer, jasper@nerdsweide.nl
+Jasper N. Brouwer, jasper@future500.nl
 
-Ramon de la Fuente, ramon@delafuente.nl
+Ramon de la Fuente, ramon@future500.nl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Jasper N. Brouwer, Ramon de la Fuente"
   description: Install latest PHP (development package) version in DotDeb repository
   company: Future500
-  license: LGPL
+  license: LGPL-3.0
   min_ansible_version: 1.4
   platforms:
   - name: Debian


### PR DESCRIPTION
I'm not sure what to do with Galaxy in this case.

- Simply keep it as is? (v0.9 should still be usable).
- Remove it? (`f500.php7` includes what this role does).
- Update it to v1.0.0 as well?

See f500/ansible-php7#1